### PR TITLE
fix: naming x86 to amd64

### DIFF
--- a/deployments/scripts/identity/install_issuer.sh
+++ b/deployments/scripts/identity/install_issuer.sh
@@ -7,6 +7,11 @@ set -e
 # Global vars
 ######################################################################
 BINARY_ARCH=$(uname -m)
+if [ "$BINARY_ARCH" = "x86_64" ]; then
+  BINARY_ARCH="amd64"
+elif [ "$BINARY_ARCH" = "aarch64" ]; then
+  BINARY_ARCH="arm64"
+fi
 BINARY_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 BINARY_NAME="identity"
 LATEST_BINARY_URI="https://github.com/agntcy/identity/releases/latest/download/${BINARY_NAME}_${BINARY_OS}_${BINARY_ARCH}"


### PR DESCRIPTION
# Description

This change updates the [install_issuer.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) script to ensure compatibility with system architecture and improve error handling during binary downloads. Specifically:

Maps uname -m output (x86_64 and aarch64) to the corresponding architecture names (amd64 and arm64) used in the release binaries.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/identity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
